### PR TITLE
fix: Add symbolic link to NextJS Dockerfile

### DIFF
--- a/pages/instructions/nextjs.js
+++ b/pages/instructions/nextjs.js
@@ -95,6 +95,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
+RUN ln -s /tmp /app/.next/cache
+
 EXPOSE 3000
 
 ENV PORT 3000


### PR DESCRIPTION
Symbolic link `/app/.next/cache` to `/tmp` directory because of read-only file system.